### PR TITLE
Fixed relative link so example works out of the box.

### DIFF
--- a/test/browser/test.html
+++ b/test/browser/test.html
@@ -18,7 +18,7 @@
         if (!expr) throw new Error(msg || 'failed');
       }
     </script>
-    <script src="./pako.js"></script>
+    <script src="../../dist/pako.js"></script>
     <script src="./test.js"></script>
     <script>
      onload = function(){


### PR DESCRIPTION
Examples should work out of the box. `pako.js` does not exist in `test/browser/` after git clone. Pointing it to `dist/pako.js` in stead fixes this.
