### PR TITLE
Fix arraySet where the dest is a Node buffer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ test: lint
 
 test-browser: lint
 	rm -f ./test/browser/pako.js
-	browserify -r ./ -s pako > test/browser/pako.js
+	browserify --detect-globals false -r ./ -s pako > test/browser/pako.js
 	@SAUCE_PROJ=${GITHUB_PROJ} grunt test
 
 cover:
@@ -48,13 +48,13 @@ browserify:
 	mkdir dist
 	# Browserify
 	( echo -n "/* ${NPM_PACKAGE} ${NPM_VERSION} ${GITHUB_PROJ} */" ; \
-		browserify -r ./ -s pako \
+		browserify --detect-globals false -r ./ -s pako \
 		) > dist/pako.js
 	( echo -n "/* ${NPM_PACKAGE} ${NPM_VERSION} ${GITHUB_PROJ} */" ; \
-		browserify -r ./lib/deflate.js -s pako \
+		browserify --detect-globals false -r ./lib/deflate.js -s pako \
 		) > dist/pako_deflate.js
 	( echo -n "/* ${NPM_PACKAGE} ${NPM_VERSION} ${GITHUB_PROJ} */" ; \
-		browserify -r ./lib/inflate.js -s pako \
+		browserify --detect-globals false -r ./lib/inflate.js -s pako \
 		) > dist/pako_inflate.js
 	# Minify
 	uglifyjs dist/pako.js -c -m \

--- a/lib/zlib/utils.js
+++ b/lib/zlib/utils.js
@@ -4,6 +4,9 @@
 var TYPED_OK =  (typeof Uint8Array !== 'undefined') &&
                 (typeof Uint16Array !== 'undefined') &&
                 (typeof Int32Array !== 'undefined');
+                
+var HAS_BUFFERS = typeof Buffer !== 'undefined' && 
+                  typeof Buffer.isBuffer === 'function';
 
 
 exports.assign = function (obj /*from1, from2, from3, ...*/) {
@@ -40,7 +43,7 @@ var fnTyped = {
   arraySet: function (dest, src, src_offs, len, dest_offs) {
     // Suppose, that with typed array support destination is
     // always typed - don't check it
-    if (src.subarray) {
+    if (src.subarray && (!HAS_BUFFERS || !Buffer.isBuffer(dest))) {
       dest.set(src.subarray(src_offs, src_offs+len), dest_offs);
       return;
     }


### PR DESCRIPTION
I'm using the zstream interface directly instead of the inflate/deflate wrappers.  Basically, I'm building a  Node API compatible wrapper for use in browserify. If `strm.next_out` is set to a Node Buffer (or a browserify one) and typed arrays are present, `utils.arraySet` breaks.  This is because the source buffer might be a typed array still so the test whether to use the typed array's subarray still passes, but the dest isn't a typed array so it breaks.

This just does a quick check to see if buffers are present and whether the dest is a buffer, and falls back to the normal loop copy if so.
