### PR TITLE
fix inflate.push()

### DIFF
--- a/lib/zlib/inflate.js
+++ b/lib/zlib/inflate.js
@@ -1446,7 +1446,7 @@ function inflate(strm, flush) {
   strm.data_type = state.bits + (state.last ? 64 : 0) +
                     (state.mode === TYPE ? 128 : 0) +
                     (state.mode === LEN_ || state.mode === COPY_ ? 256 : 0);
-  if (((_in === 0 && _out === 0) || flush === Z_FINISH) && ret === Z_OK) {
+  if (flush === Z_FINISH && ret === Z_OK) {
     ret = Z_BUF_ERROR;
   }
   return ret;


### PR DESCRIPTION
Recently found an error in the implementation of the Inflate class. 

Here are some examples:

Original:
http://jsfiddle.net/SLYD6/1/
With patch applied:
http://jsfiddle.net/VEmDA/

The example generates a ~16kb random byte array, compresses, and then decompress it using the Inflate class, feeding it byte by byte. The original version shows an error.
