### PR TITLE
Throw on inflate(ArrayBuffer)

### DIFF
--- a/lib/inflate.js
+++ b/lib/inflate.js
@@ -182,6 +182,9 @@ Inflate.prototype.push = function(data, mode) {
     // Only binary strings can be decompressed on practice
     strm.input = strings.binstring2buf(data);
   } else {
+    if (typeof ArrayBuffer !== 'undefined' && data instanceof ArrayBuffer) {
+      throw 'Pass Uint8Array to pako, not an ArrayBuffer';
+    }
     strm.input = data;
   }
 

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -38,5 +38,16 @@ describe('Generic', function () {
       assert(cmp(data_bin, pako.inflate(pako.deflate(data_bin, { level: 6 }))));
     });
   });
+
+  it('should fail on ArrayBuffers', function() {
+    var ok = false;
+    try {
+      pako.inflate(new ArrayBuffer());
+    } catch(e) {
+      ok = true;
+      assert(/Uint8Array/.exec(e), 'Error should mention Uint8Array');
+    }
+    assert(ok, 'Inflating an ArrayBuffer should throw');
+  });
 });
 


### PR DESCRIPTION
This is an extremely common mistake when using pako in-browser.

The current error message is extremely misleading:

    Uncaught unknown compression method

This pull request changes it to something more helpful:

    Pass Uint8Array to pako, not an ArrayBuffer