### PR TITLE
removing unnecessary js extension

### DIFF
--- a/lib/deflate.js
+++ b/lib/deflate.js
@@ -1,7 +1,7 @@
 'use strict';
 
 
-var zlib_deflate = require('./zlib/deflate.js');
+var zlib_deflate = require('./zlib/deflate');
 var utils = require('./utils/common');
 var strings = require('./utils/strings');
 var msg = require('./zlib/messages');

--- a/lib/inflate.js
+++ b/lib/inflate.js
@@ -1,7 +1,7 @@
 'use strict';
 
 
-var zlib_inflate = require('./zlib/inflate.js');
+var zlib_inflate = require('./zlib/inflate');
 var utils = require('./utils/common');
 var strings = require('./utils/strings');
 var c = require('./zlib/constants');


### PR DESCRIPTION
The `.js` extensions on the import of the zlib inflate+deflate modules were breaking our requirejs setup.

I think this change should be relatively harmless, and I've verified with the test+browserify commands provided.

Thanks!