### PR TITLE
Support non-bash shells in "make browserify"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,13 +45,13 @@ browserify:
 	rm -rf ./dist
 	mkdir dist
 	# Browserify
-	( echo -n "/* ${NPM_PACKAGE} ${NPM_VERSION} ${GITHUB_PROJ} */" ; \
+	( printf %s "/* ${NPM_PACKAGE} ${NPM_VERSION} ${GITHUB_PROJ} */" ; \
 		./node_modules/.bin/browserify -r ./ -s pako \
 		) > dist/pako.js
-	( echo -n "/* ${NPM_PACKAGE} ${NPM_VERSION} ${GITHUB_PROJ} */" ; \
+	( printf %s "/* ${NPM_PACKAGE} ${NPM_VERSION} ${GITHUB_PROJ} */" ; \
 		./node_modules/.bin/browserify -r ./lib/deflate.js -s pako \
 		) > dist/pako_deflate.js
-	( echo -n "/* ${NPM_PACKAGE} ${NPM_VERSION} ${GITHUB_PROJ} */" ; \
+	( printf %s "/* ${NPM_PACKAGE} ${NPM_VERSION} ${GITHUB_PROJ} */" ; \
 		./node_modules/.bin/browserify -r ./lib/inflate.js -s pako \
 		) > dist/pako_inflate.js
 	# Minify


### PR DESCRIPTION
This fixes "-n" to do what it's supposed to do, instead of printing a literal "-n" to the file in OS X.

http://stackoverflow.com/a/25840639/14431