### PR TITLE
correct grunt dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "ndoc": "*",
     "lodash": "*",
     "async": "*",
-    "grunt": "~0.4.4",
+    "grunt": ">=0.4.0",
     "grunt-cli": "~0.1.13",
     "grunt-saucelabs": "~8.6.0",
     "grunt-contrib-connect": "~0.9.0"


### PR DESCRIPTION
I had Pako installed as a 3rd level dependency under Webpack and kept getting an error with npm

```
└── UNMET PEER DEPENDENCY grunt@1.0.1
```

Tracked it down to this package by running `fgrep 'grunt' **/package.json` and reviewing the output.

> If you have a Grunt plugin that includes grunt in the peerDependencies section of your package.json, we recommend tagging with "grunt": ">=0.4.0". Otherwise for npm@2 users grunt@1.0.0 will receive a hard error when trying to install your plugin and npm@3 users will get a warning. We have sent over two thousand pull requests to existing plugins to make this change.
> http://gruntjs.com/blog
