### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 pako
 ==========================================
 
-zlib port to javascript, very fast!
-
 [![Build Status](https://travis-ci.org/nodeca/pako.svg?branch=master)](https://travis-ci.org/nodeca/pako)
 [![NPM version](https://img.shields.io/npm/v/pako.svg)](https://www.npmjs.org/package/pako)
+
+> zlib port to javascript, very fast!
 
 __Why pako is cool:__
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-pako - zlib port to javascript, very fast!
+pako
 ==========================================
+
+zlib port to javascript, very fast!
 
 [![Build Status](https://travis-ci.org/nodeca/pako.svg?branch=master)](https://travis-ci.org/nodeca/pako)
 [![NPM version](https://img.shields.io/npm/v/pako.svg)](https://www.npmjs.org/package/pako)


### PR DESCRIPTION
When this readme get's imported to npmjs.org, the title is replaced with the npm package name, so the description is missing. I suggest moving the description down into the body of the readme so it will show up on npmjs.org.