### PR TITLE
Broken on Node 8.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - "8"
+  - "8.4"
 script: make $COMMAND
 env:
   matrix:

--- a/lib/utils/common.js
+++ b/lib/utils/common.js
@@ -17,7 +17,7 @@ exports.assign = function (obj /*from1, from2, from3, ...*/) {
     }
 
     for (var p in source) {
-      if (source.hasOwnProperty(p)) {
+      if (Object.prototype.hasOwnProperty.call(source, p)) {
         obj[p] = source[p];
       }
     }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -94,7 +94,7 @@ function testInflate(samples, inflateOptions, deflateOptions) {
   // inflate options have windowBits = 0 to force autodetect window size
   //
   for (name in samples) {
-    if (!Object.prototype.hasOwnProperty.call(samples,name)) continue;
+    if (!Object.prototype.hasOwnProperty.call(samples, name)) continue;
     data = samples[name];
 
     // always use the same data type to generate sample

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -94,7 +94,7 @@ function testInflate(samples, inflateOptions, deflateOptions) {
   // inflate options have windowBits = 0 to force autodetect window size
   //
   for (name in samples) {
-    if (!samples.hasOwnProperty(name)) continue;
+    if (!Object.prototype.hasOwnProperty.call(samples,name)) continue;
     data = samples[name];
 
     // always use the same data type to generate sample


### PR DESCRIPTION
Pako is broken on Node 8.4.0, the error is the same as reported in [this issue](https://github.com/aseemk/requireDir/issues/45) (also see [here](https://github.com/tjunnone/npm-check-updates/issues/355)).

- This fix makes sure `hasOwnProperty` is called on `Object.prototype`
- The test is run on node@8.4.0, which is the latest stable version

