### PR TITLE
Allow raw inflation with a custom dictionary.

### DIFF
--- a/lib/inflate.js
+++ b/lib/inflate.js
@@ -144,6 +144,20 @@ function Inflate(options) {
   this.header = new GZheader();
 
   zlib_inflate.inflateGetHeader(this.strm, this.header);
+  
+  // With a raw dictionary, we need to set the dictionary early.
+  if (opt.raw && opt.dictionary) {
+    var dict;
+    // Convert data if needed
+    if (typeof opt.dictionary === 'string') {
+      dict = strings.string2buf(opt.dictionary);
+    } else if (toString.call(opt.dictionary) === '[object ArrayBuffer]') {
+      dict = new Uint8Array(opt.dictionary);
+    } else {
+      dict = opt.dictionary;
+    }
+    zlib_inflate.inflateSetDictionary(this.strm, dict);
+  }
 }
 
 /**
@@ -211,7 +225,8 @@ Inflate.prototype.push = function (data, mode) {
 
     status = zlib_inflate.inflate(strm, c.Z_NO_FLUSH);    /* no bad return value */
 
-    if (status === c.Z_NEED_DICT && dictionary) {
+    // We have already set the dictionary if we used a raw stream.
+    if (!this.options.raw && status === c.Z_NEED_DICT && dictionary) {
       // Convert data if needed
       if (typeof dictionary === 'string') {
         dict = strings.string2buf(dictionary);

--- a/lib/inflate.js
+++ b/lib/inflate.js
@@ -144,7 +144,7 @@ function Inflate(options) {
   this.header = new GZheader();
 
   zlib_inflate.inflateGetHeader(this.strm, this.header);
-  
+
   // With a raw dictionary, we need to set the dictionary early.
   if (opt.raw && opt.dictionary) {
     var dict;


### PR DESCRIPTION
This is just roughly tested, but I just ported the
change from nodejs/node#8512, or at least attempted to.

Before, when trying to inflateRaw (or inflate({raw:true});) with a custom
dictionary, you would get 'invalid distance too far back'.

This no longer seems to happen, so I think I fixed it.

I wasn't able to get browserify working, but I successfully tested it in the REPL. 

Feel free to reformat or move things if necessary. I won't call myself the best at following code style.