### PR TITLE
Patch 1

### DIFF
--- a/lib/utils/strings.js
+++ b/lib/utils/strings.js
@@ -86,15 +86,15 @@ function buf2binstring(buf, len) {
   var i, result = '';
 
   if ((buf.subarray && STR_APPLY_UIA_OK) || (!buf.subarray && STR_APPLY_OK)) {
-	  var chunk = 65536;
+    var chunk = 65536;
     if (len <= chunk) { // keeping this for short strings is a little faster than chunking if the buf isn't shrunk
       return String.fromCharCode.apply(null, utils.shrinkBuf(buf, len));
     }
     // else, chunking with fast method ~3x faster on MB strings than fallback
     for (i = 0; i < len; i += chunk) {   
-		  if (chunk > len - i) chunk = len - i; // last chunk
-		  result += String.fromCharCode.apply(null, buf.slice(i , i + chunk)); // you might want some util other than slice
-	  }
+      if (chunk > len - i) chunk = len - i; // last chunk
+      result += String.fromCharCode.apply(null, buf.slice(i , i + chunk)); // you might want some util other than slice
+    }
     return result;
   }
   // else fallback

--- a/lib/utils/strings.js
+++ b/lib/utils/strings.js
@@ -86,8 +86,8 @@ function buf2binstring(buf, len) {
   var i, result = '';
 
   if ((buf.subarray && STR_APPLY_UIA_OK) || (!buf.subarray && STR_APPLY_OK)) {
-	  var chunk = 65537;
-    if (len < chunk) { // keeping this for short strings is a little faster than chunking if the buf isn't shrunk
+	  var chunk = 65536;
+    if (len <= chunk) { // keeping this for short strings is a little faster than chunking if the buf isn't shrunk
       return String.fromCharCode.apply(null, utils.shrinkBuf(buf, len));
     }
     // else, chunking with fast method ~3x faster on MB strings than fallback

--- a/lib/utils/strings.js
+++ b/lib/utils/strings.js
@@ -83,15 +83,22 @@ exports.string2buf = function (str) {
 
 // Helper (used in 2 places)
 function buf2binstring(buf, len) {
-  // use fallback for big arrays to avoid stack overflow
-  if (len < 65537) {
-    if ((buf.subarray && STR_APPLY_UIA_OK) || (!buf.subarray && STR_APPLY_OK)) {
+  var i, result = '';
+
+  if ((buf.subarray && STR_APPLY_UIA_OK) || (!buf.subarray && STR_APPLY_OK)) {
+	  var chunk = 65537;
+    if (len < chunk) { // keeping this for short strings is a little faster than chunking if the buf isn't shrunk
       return String.fromCharCode.apply(null, utils.shrinkBuf(buf, len));
     }
+    // else, chunking with fast method ~3x faster on MB strings than fallback
+    for (i = 0; i < len; i += chunk) {   
+		  if (chunk > len - i) chunk = len - i; // last chunk
+		  result += String.fromCharCode.apply(null, buf.slice(i , i + chunk)); // you might want some util other than slice
+	  }
+    return result;
   }
-
-  var result = '';
-  for (var i = 0; i < len; i++) {
+  // else fallback
+  for (i = 0; i < len; i++) {
     result += String.fromCharCode(buf[i]);
   }
   return result;

--- a/lib/utils/strings.js
+++ b/lib/utils/strings.js
@@ -91,9 +91,9 @@ function buf2binstring(buf, len) {
       return String.fromCharCode.apply(null, utils.shrinkBuf(buf, len));
     }
     // else, chunking with fast method ~3x faster on MB strings than fallback
-    for (i = 0; i < len; i += chunk) {   
+    for (i = 0; i < len; i += chunk) {
       if (chunk > len - i) chunk = len - i; // last chunk
-      result += String.fromCharCode.apply(null, buf.slice(i , i + chunk)); // you might want some util other than slice
+      result += String.fromCharCode.apply(null, buf.slice(i, i + chunk)); // you might want some util other than slice
     }
     return result;
   }


### PR DESCRIPTION
Changed buf2binstring() to use fast `apply` method by chunking large strings. I've tested this code in my project in the major browsers, but not in Pako and node. This buf2binstring is a few times faster in my tests with MB strings than falling back to `+= String.fromCharCode(buf[i])`, except in Chrome where it is >8x faster as string begins exceeding ~400kb. 

Disclaimer: I'm fairly new to js and github, so apologies if I'm going about this the wrong way or writing naive code. 