### PR TITLE
[utils] fix RangeError on chrome71

### DIFF
--- a/lib/utils/strings.js
+++ b/lib/utils/strings.js
@@ -83,7 +83,9 @@ exports.string2buf = function (str) {
 
 // Helper (used in 2 places)
 function buf2binstring(buf, len) {
-  // use fallback for big arrays to avoid stack overflow
+  // On Chrome, the arguments in a function call that are allowed is `65534`.
+  // If the length of the buffer is smaller than that, we can use this optimization,
+  // otherwise we will take a slower path.
   if (len < 65534) {
     if ((buf.subarray && STR_APPLY_UIA_OK) || (!buf.subarray && STR_APPLY_OK)) {
       return String.fromCharCode.apply(null, utils.shrinkBuf(buf, len));

--- a/lib/utils/strings.js
+++ b/lib/utils/strings.js
@@ -84,7 +84,7 @@ exports.string2buf = function (str) {
 // Helper (used in 2 places)
 function buf2binstring(buf, len) {
   // use fallback for big arrays to avoid stack overflow
-  if (len < 65537) {
+  if (len < 65534) {
     if ((buf.subarray && STR_APPLY_UIA_OK) || (!buf.subarray && STR_APPLY_OK)) {
       return String.fromCharCode.apply(null, utils.shrinkBuf(buf, len));
     }


### PR DESCRIPTION
Fixes the following error: RangeError: Too many arguments in function call (only 65534 allowed)
The argument limit seems to have become lower in chrome 71...