### PR TITLE
Update package.js license to match LICENSE file

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "dist/",
     "lib/"
   ],
-  "license": "(MIT AND Zlib)",
+  "license": "MIT",
   "repository": "nodeca/pako",
   "scripts": {
     "test": "make test"


### PR DESCRIPTION
The LICENSE file declares a standard MIT license, but the package.json file declared a "(MIT AND Zlib)" license. This mismatch causes tools like license_finder to fail to recognize the correct license for this package.