### PR TITLE
Add subpath exports for deflate & inflate for tree-shaking support

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,16 @@
   "repository": "nodeca/pako",
   "module": "./dist/pako.esm.mjs",
   "exports": {
-    "import": "./dist/pako.esm.mjs",
-    "require": "./index.js"
+    ".": {
+      "import": "./dist/pako.esm.mjs",
+      "require": "./index.js"
+    },
+    "./deflate": {
+      "require": "./lib/deflate.js"
+    },
+    "./inflate": {
+      "require": "./lib/inflate.js"
+    }
   },
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
This adds [subpath exports](https://nodejs.org/api/packages.html#packages_subpath_exports) for `deflate` & `inflate` to add tree-shaking support when used with RollUp.

I was building a small project and noticed that it was not tree-shaking out `deflate` at all, and was able to fix the issue locally with this new subpath.

```js
const pako = require('pako/inflate');
const out = pako.inflate(data);
```