### PR TITLE
doc: add download badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ pako
 
 [![CI](https://github.com/nodeca/pako/workflows/CI/badge.svg)](https://github.com/nodeca/pako/actions)
 [![NPM version](https://img.shields.io/npm/v/pako.svg)](https://www.npmjs.org/package/pako)
+[![NPM downloads](https://img.shields.io/npm/dm/pako.svg)](https://npm-compare.com/pako/#timeRange=FIVE_YEARS)
 
 > zlib port to javascript, very fast!
 


### PR DESCRIPTION
Hi, I’ve added a badge to the README that allows users to view the dynamic download trends of [pako](https://npm-compare.com/pako/#timeRange=FIVE_YEARS). This change enables new users to easily see the download history of the package, providing more confidence in its popularity and adoption.

As a maintainer of npm-compare.com, I’m happy to assist with any additional features or insights from our site if needed.

Thanks for considering my suggestion!