### PR TITLE
Fix _utf8len typo for byte 0xFF in buf2string

### DIFF
--- a/lib/utils/strings.js
+++ b/lib/utils/strings.js
@@ -19,7 +19,7 @@ const _utf8len = new Uint8Array(256);
 for (let q = 0; q < 256; q++) {
   _utf8len[q] = (q >= 252 ? 6 : q >= 248 ? 5 : q >= 240 ? 4 : q >= 224 ? 3 : q >= 192 ? 2 : 1);
 }
-_utf8len[254] = _utf8len[254] = 1; // Invalid sequence start
+_utf8len[254] = _utf8len[255] = 1; // Invalid sequence start
 
 
 // convert string to array (typed, when possible)

--- a/test/strings.js
+++ b/test/strings.js
@@ -103,6 +103,20 @@ describe('Encode/Decode', () => {
     assert.ok(strings.buf2string(utf8sample), utf16sample);
   });
 
+  it('0xFF byte should not consume subsequent bytes', () => {
+    TextDecoder = null;
+
+    // 0xFF is invalid UTF-8. With the bug (_utf8len[255] = 6), buf2string
+    // treats it as a 6-byte sequence, swallowing the next 5 valid bytes.
+    const buf = new Uint8Array([ 0xFF, 0x41, 0x42, 0x43, 0x44, 0x45 ]);
+    const result = strings.buf2string(buf);
+
+    // Should produce 6 characters: one for the invalid 0xFF byte,
+    // then 'A', 'B', 'C', 'D', 'E'
+    assert.strictEqual(result.length, 6);
+    assert.strictEqual(result.slice(1), 'ABCDE');
+  });
+
 });
 
 


### PR DESCRIPTION
_utf8len[254] = _utf8len[254] = 1 was a typo that assigned index 254 twice, leaving _utf8len[255] at its loop-computed value of 6. Byte 0xFF is invalid UTF-8 and should map to length 1. When buf2string encountered a 0xFF byte, it would treat it as a 6-byte sequence, consuming up to 5 subsequent bytes and producing incorrect output.