### PR TITLE
Address Uint8Array versus Uint8Array<ArrayBuffer>

### DIFF
--- a/src/deflate.ts
+++ b/src/deflate.ts
@@ -7,7 +7,7 @@ import {
   zlibDeflateEnd
 } from './zlib.mjs';
 import type { Z_CallStatus, Z_FlushMode } from './zlib.mjs';
-import { flattenChunks } from './utils.ts';
+import { flattenChunks, type NonSharedUint8Array } from './utils.ts';
 
 const toString = Object.prototype.toString;
 
@@ -130,7 +130,7 @@ class Deflate {
    * and {@link Deflate.onEnd} handlers. Filled after you push last chunk
    * (call {@link Deflate.push} with {@link Z_FINISH} / `true` param).
    */
-  result: Uint8Array;
+  result: NonSharedUint8Array;
 
   /**
    * Creates a new deflator instance with the specified params. Throws an
@@ -355,7 +355,7 @@ class Deflate {
  * console.log(deflate(data))
  * ```
  */
-function deflate(input: DeflateInput, options: DeflateOptions = {}): Uint8Array {
+function deflate(input: DeflateInput, options: DeflateOptions = {}): NonSharedUint8Array {
   const deflator = new Deflate(options);
 
   deflator.push(input, true);
@@ -371,7 +371,7 @@ function deflate(input: DeflateInput, options: DeflateOptions = {}): Uint8Array 
  * The same as {@link deflate}, but creates raw data without a wrapper
  * (header and adler32 crc).
  */
-function deflateRaw(input: DeflateInput, options: DeflateOptions = {}): Uint8Array {
+function deflateRaw(input: DeflateInput, options: DeflateOptions = {}): NonSharedUint8Array {
   return deflate(input, Object.assign({}, options, { raw: true }));
 }
 
@@ -380,7 +380,7 @@ function deflateRaw(input: DeflateInput, options: DeflateOptions = {}): Uint8Arr
  * The same as {@link deflate}, but creates a gzip wrapper instead of
  * a deflate one.
  */
-function gzip(input: DeflateInput, options: DeflateOptions = {}): Uint8Array {
+function gzip(input: DeflateInput, options: DeflateOptions = {}): NonSharedUint8Array {
   return deflate(input, Object.assign({}, options, { gzip: true }));
 }
 

--- a/src/inflate.ts
+++ b/src/inflate.ts
@@ -8,7 +8,7 @@ import {
   zlibInflateEnd
 } from './zlib.mjs';
 import type { Z_CallStatus, Z_FlushMode } from './zlib.mjs';
-import { flattenChunks } from './utils.ts';
+import { flattenChunks, type NonSharedUint8Array } from './utils.ts';
 
 const toString = Object.prototype.toString;
 
@@ -97,7 +97,7 @@ class Inflate {
    * and {@link Inflate.onEnd} handlers. Filled after you push last chunk
    * (call {@link Inflate.push} with {@link Z_FINISH} / `true` param).
    */
-  result: Uint8Array;
+  result: NonSharedUint8Array;
 
   /**
    * Creates a new inflator instance with the specified params. Throws an
@@ -429,7 +429,7 @@ class Inflate {
 function inflate<O extends InflateOptions & { toText?: boolean }>(
   input: InflateInput,
   options: O = {} as O
-): O extends { toText: true } ? string : Uint8Array {
+): O extends { toText: true } ? string : NonSharedUint8Array {
   const inflator = new Inflate(options);
 
   inflator.push(input, true);
@@ -440,7 +440,7 @@ function inflate<O extends InflateOptions & { toText?: boolean }>(
   const result = inflator.result;
 
   return (options.toText ? new TextDecoder().decode(result) : result) as
-    O extends { toText: true } ? string : Uint8Array;
+    O extends { toText: true } ? string : NonSharedUint8Array;
 }
 
 
@@ -451,7 +451,7 @@ function inflate<O extends InflateOptions & { toText?: boolean }>(
 function inflateRaw<O extends InflateOptions & { toText?: boolean }>(
   input: InflateInput,
   options: O = {} as O
-): O extends { toText: true } ? string : Uint8Array {
+): O extends { toText: true } ? string : NonSharedUint8Array {
   return inflate<O>(input, { ...options, raw: true } as O);
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,10 @@
+// Handle Uint8Array (pre TS 5.9) vs. Uint8Array<ArrayBuffer> (TS 5.9+)
+// https://github.com/microsoft/TypeScript/issues/62240#issuecomment-3288389211
+/** @inline */
+export type NonSharedUint8Array = ReturnType<typeof Uint8Array.from>;
+
 // Join array of chunks to single array.
-export const flattenChunks = (chunks: Uint8Array[]): Uint8Array => {
+export const flattenChunks = (chunks: Uint8Array[]): NonSharedUint8Array => {
   const result = new Uint8Array(chunks.reduce((len, chunk) => len + chunk.length, 0));
   let pos = 0;
 


### PR DESCRIPTION
TypeScript 5.9 made Uint8Array a generic type over Uint8Array<ArrayBufferLike>. This works fine for pako's input types (I'm assuming that it can work with either Uint8Array), but it may result in TypeScript errors when used with pako's output types, because common APIs like fetch expect a Uint8Array<ArrayBuffer> instead of the generic Uint8Array<ArrayBufferLike>.

In practice, pako's output types always use Uint8Array<ArrayBuffer>, so its types can be updated to reflect that. For compatibility with TypeScript versions prior to 5.9, I used the idiom from https://github.com/microsoft/TypeScript/issues/62240#issuecomment-3288389211 to make a type alias that should work in any supported TS version.

This PR only updates the higher-level APIs (standalone functions and `.result` members). `onData` could likely also be updated, but that would involve changes to the bundled zlib types, so it's more complicated.

Fixes #307