### PR TITLE
Read gzip header time as unsigned 32-bit

### DIFF
--- a/src/zlib/inflate.mjs
+++ b/src/zlib/inflate.mjs
@@ -557,7 +557,7 @@ const inflate = (strm, flush) => {
         }
         //===//
         if (state.head) {
-          state.head.time = hold;
+          state.head.time = hold >>> 0;
         }
         if ((state.flags & 0x0200) && (state.wrap & 4)) {
           //=== CRC4(state.check, hold)

--- a/test/gzip_specials.test.mjs
+++ b/test/gzip_specials.test.mjs
@@ -76,6 +76,29 @@ describe('Gzip special cases', () => {
     assert.deepStrictEqual(header.extra, new Uint8Array([ 4, 5, 6 ]));
   });
 
+  it('Read header time past the signed 32-bit boundary (2038) as unsigned', () => {
+    // RFC 1952: MTIME is an unsigned 32-bit value. Timestamps from 2038-01-19
+    // on have bit 31 set and must not be reported as a negative number.
+    const time = 0x80000000;
+
+    const deflator = new Deflate({ gzip: true });
+    deflator.onStart = function (strm) {
+      const header = new GZheader();
+      header.time = time;
+      zlibDeflateSetHeader(strm, header);
+    };
+    deflator.push('x', true);
+
+    const inflator = new Inflate();
+    inflator.onStart = function (strm) {
+      this.header = new GZheader();
+      zlibInflateGetHeader(strm, this.header);
+    };
+    inflator.push(deflator.result);
+
+    assert.strictEqual(inflator.header.time, time);
+  });
+
   it('Read stream with SYNC marks (multistream source, file 1)', () => {
     const data = fs.readFileSync(path.join(__dirname, 'fixtures/gzip-joined.gz'));
 


### PR DESCRIPTION
`inflate` reads the gzip header MTIME into `head.time` as a signed 32-bit value, so any timestamp with bit 31 set is reported as a negative number.

RFC 1952 (§2.3.1) defines MTIME as an unsigned 32-bit integer, and zlib's `gz_header.time` is a `uLong`. In `inflate.mjs` the four MTIME bytes are accumulated into `hold` (the top byte via `<< 24`, which is signed in JS) and stored directly:

```js
if (state.head) {
  state.head.time = hold;
}
```

Every mtime from 2038-01-19 03:14:08 UTC onward has bit 31 set, so `head.time` comes back negative instead of the real value.

Repro:

```js
import { Deflate, Inflate, GZheader, zlibDeflateSetHeader, zlibInflateGetHeader } from 'pako';

const def = new Deflate({ gzip: true });
def.onStart = strm => { const h = new GZheader(); h.time = 0x80000000; zlibDeflateSetHeader(strm, h); };
def.push('x', true);

const inf = new Inflate();
inf.onStart = function (strm) { this.header = new GZheader(); zlibInflateGetHeader(strm, this.header); };
inf.push(def.result);

console.log(inf.header.time); // -2147483648, want 2147483648
```

Fix: coerce to unsigned with `>>> 0`, matching the unsigned semantics of the field. Adds a regression test round-tripping an mtime past the signed 32-bit boundary.
